### PR TITLE
FEAT: replace function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# stencil-router-v2
+# @altafonte/router
 
-Stencil Router V2 is an experimental new router for stencil that focus in:
+This package is a fork of [@sethealth/router](https://www.npmjs.com/package/@sethealth/router) which is a fork of [Stencil Router V2](https://www.npmjs.com/package/stencil-router-v2), an experimental new router for stencil that focus in:
 
 - **Lightweight** (600bytes)
 - **Treeshakable** (not used features are not included in the final build)
@@ -8,23 +8,26 @@ Stencil Router V2 is an experimental new router for stencil that focus in:
 - **No DOM**: Router is not render any extra DOM element, to keep styling simple.
 - **Fast**: As fast and lightweight as writing your own router with if statements.
 
+## Features added to original @sethealth/router
+
+- The `push` function accepts a second param as options, where you can tell to `replace`, so it uses `history.replaceState` instead `history.pushState`. This is intended to be used on automatic redirections, so you don't break the back/forward feature on navigators.
+
 ## How does it work?
 
 This router backs up the `document.location` in a `@stencil/store`, this way we can respond to changes in document.location is a much simpler, way, not more subscribes, no more event listeners events to connect and disconnect.
 
 Functional Components are the used to collect the list of routes, finally the `Switch` renders only the selected route.
 
-
 ## Install
 
 ```bash
-npm install stencil-router-v2 --save-dev
+npm install @altafonte/router
 ```
 
 ## Examples
 
 ```tsx
-import { createRouter, Route } from 'stencil-router-v2';
+import { createRouter, Route } from '@altafonte/router';
 
 const Router = createRouter();
 
@@ -55,6 +58,7 @@ export class AppRoot {
 ```
 
 ### Redirects
+
 ```tsx
 <Host>
   <Router.Switch>
@@ -66,15 +70,29 @@ export class AppRoot {
 </Host>
 ```
 
+```tsx
+<Host>
+  <Router.Switch>
+
+    <Route path={match("/colors/:type")} render={({ type }) => {
+      if (!["black", "white"].includes(type)) {
+        return Router.push("/colors/black", { replace: true })
+      }
+      return <valid-color-component color={type}/>
+    }}/>
+
+  </Router.Switch>
+</Host>
+```
+
 ### Params
 
 Route can take an optional `render` property that will pass down the params. This method should be used instead of JSX children.
 
 Regex or functional matches have the chance to generate an object of params when the URL matches.
 
-
 ```tsx
-import { createRouter, Route, match } from 'stencil-router-v2';
+import { createRouter, Route, match } from '@altafonte/router';
 
 const Router = createRouter();
 
@@ -114,7 +132,7 @@ const Router = createRouter();
 The `href()` function will inject all the handles to an native `anchor`, without extra DOM.
 
 ```tsx
-import { createRouter, Route, href } from 'stencil-router-v2';
+import { createRouter, Route, href } from '@altafonte/router';
 
 const Router = createRouter();
 
@@ -132,7 +150,6 @@ const Router = createRouter();
   </Router.Switch>
 </Host>
 ```
-
 
 ### Dynamic routes (guards)
 
@@ -170,7 +187,7 @@ export class AppRoot {
 Because the router uses `@stencil/store` its trivial to subscribe to changes in the locations, activeRoute, or even the list of routes.
 
 ```tsx
-import { createRouter, Route } from 'stencil-router-v2';
+import { createRouter, Route } from '@altafonte/router';
 
 const Router = createRouter();
 
@@ -222,4 +239,3 @@ The routes state includes:
   urlParams: { [key: string]: string };
   routes: RouteEntry[];
 ```
-

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This package is a fork of [@sethealth/router](https://www.npmjs.com/package/@set
 ## Features added to original @sethealth/router
 
 - The `push` function accepts a second param as options, where you can tell to `replace`, so it uses `history.replaceState` instead `history.pushState`. This is intended to be used on automatic redirections, so you don't break the back/forward feature on navigators.
+- `Router.replace(url)` is a shortcut for `Router.push(url, { replace: true })`
 
 ## How does it work?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@sethealth/router",
-  "version": "0.7.1",
+  "name": "@altafonte/router",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@sethealth/router",
-      "version": "0.7.1",
+      "name": "@altafonte/router",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@stencil/store": "^1.1.0"
@@ -2882,19 +2882,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -11405,13 +11392,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@sethealth/router",
-  "version": "0.7.2",
-  "description": "New router based in @stencil/store",
+  "name": "@altafonte/router",
+  "version": "0.8.0",
+  "description": "This is a fork of @sethealth/router, which forks stencil-router-v2",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
   "files": [
     "dist"
   ],
-  "author": "Manu Mtz.-Almeida",
+  "author": "Altafonte",
   "license": "MIT",
   "peerDependencies": {
     "@stencil/core": ">=1.10.0"
@@ -43,6 +43,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/sethealth/router.git"
+    "url": "git://github.com/altafonte/router.git"
   }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -39,6 +39,10 @@ export const createRouter = (opts?: RouterOptions): Router => {
     state.activePath = parseURL(url);
   };
 
+  const replace = (href: string) => {
+    push(href, { replace: true })
+  }
+
   const match = (routes: RouteEntry[]) => {
     const { activePath } = state;
     for (let route of routes) {
@@ -88,6 +92,7 @@ export const createRouter = (opts?: RouterOptions): Router => {
       return state.activePath;
     },
     push,
+    replace,
     onChange: onChange as any,
     dispose: disposeRouter,
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface Router {
   onChange(key: 'url', cb: OnChangeHandler<'url'>);
   onChange(key: 'activePath', cb: OnChangeHandler<'activePath'>);
   push(href: string, options?: { replace: boolean }): void;
+  replace(href: string): void;
 }
 
 export interface RouterProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export interface Router {
   dispose(): void;
   onChange(key: 'url', cb: OnChangeHandler<'url'>);
   onChange(key: 'activePath', cb: OnChangeHandler<'activePath'>);
-  push(href: string): void;
+  push(href: string, options?: { replace: boolean }): void;
 }
 
 export interface RouterProps {


### PR DESCRIPTION
This MR adds:

- Right package metadata and README docs.
- Router.replace method, that is a shortcut for Router.push(url, { replace: true }).

This feature allows automatic redirection without breaking back/forward navigator functionallity. Otherwise, if you automatically redirects from /some-url to /some-other-url, going back triggers the redirection again, so you are trapped.